### PR TITLE
Adds new loss computation infrastructure that centralizes new tensor creation and prevents future bugs of training on multi-gpu 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable chagnes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),  
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ---
 
 ## [0.4.0] - 2025-09-07
@@ -28,49 +27,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.1.0] - 2025-03-03
+## [0.3.0] - 2025-08
 
 ### Added
 
-#### Core Framework
-- Introduced a minimal yet self-contained virtual staining framework structured around modular components for model training, dataset handling, transformations, metrics, and logging.
+#### New modular backbone for `models` subpackage
+##### Major changes:
+- Introduced a new modular and extensible `models` subpackage for building image-to-image translation models. 
+The subpackage is designed around a declarative style for creating U-Net-like architectures, with a hierarchy of abstractions:
+  - **Blocks** (`blocks.py`, `up_down_blocks.py`): Smallest modular units, categorized into computational blocks (e.g., `Conv2DNormActBlock`, `Conv2DConvNeXtBlock`) and spatial dimension altering blocks (e.g., `Conv2DDownBlock`, `PixelShuffle2DUpBlock`).
+  - **Stages** (`stages.py`): Sequences of blocks for downsampling or upsampling, such as `DownStage` and `UpStage`.
+  - **Encoder** (`encoder.py`): Implements the downsampling path of U-Net-like architectures using `DownStage` objects.
+  - **Decoder** (`decoder.py`): Implements the upsampling path with skip connections using `UpStage` objects.
+  - **BaseModel** and **BaseGeneratorModel** (`model.py`): Added abstract base classes for models, including functionality for saving weights, configuration handling, and defining the forward pass.
+  - **UNet** (`unet.py`): Predefined model class supporting fully convolutional and maxpooling-based U-Net variants.
+  - **UNeXt** (`unext.py`): Predefined U-Net variant with a ConvNeXtV2_tiny encoder and customizable decoder.
+- Added utility functions for normalization layers, activation functions, and type checking of block handles and configurations.
+- Refer to the `models` README for detailed explanations of components and usage examples.
 
-#### Models (`models`)
-- Added `FNet`: Fully convolutional encoder-decoder for image-to-image translation.
-- Added `UNet`: U-Net variant using bilinear interpolation for upsampling.
-- Added GaN discriminators:
-  - `PatchBasedDiscriminator`: Outputs a probability map.
-  - `GlobalDiscriminator`: Outputs a global scalar probability.
+### Refactored 
 
-#### Transforms (`transforms`)
-- `MinMaxNormalize`: Albumentations transform for range-based normalization.
-- `ZScoreNormalize`: Albumentations transform for z-score normalization.
-- `PixelDepthTransform`: Converts between image bit depths (e.g., 16-bit to 8-bit).
-
-#### Datasets (`datasets`)
-- `ImageDataset`: Dynamically loads multi-channel microscopy images from a PE2LoadData-formatted CSV; supports input/target channel selection and Albumentations transforms.
-- `PatchDataset`: Extends `ImageDataset` with configurable fixed-size cropping; supports object-centric patching and state retrieval (e.g., patch coordinates).
-- `GenericImageDataset`: A simplified dataset for user-formatted directories using regex-based site/channel parsing.
-- `CachedDataset`: Caches any of the above datasets in RAM to reduce I/O and speed up training.
-
-#### Losses (`losses`)
-- `AbstractLoss`: Base class defining standardized loss interface and trainer binding.
-- `GeneratorLoss`: Combines image reconstruction and adversarial loss for training GaN generators.
-- `WassersteinLoss`: Computes Wasserstein distance for GaN discriminator training.
-- `GradientPenaltyLoss`: Adds gradient penalty to improve discriminator stability.
-
-#### Metrics (`metrics`)
-- `AbstractMetrics`: Base class for accumulating, aggregating, and resetting batch-wise metrics.
-- `MetricsWrapper`: Wraps `torch.nn.Module` metrics with accumulation and aggregation logic.
-- `PSNR`: Computes Peak Signal-to-Noise Ratio (PSNR) for image quality evaluation.
-
-#### Callbacks (`callbacks`)
-- `AbstractCallback`: Base class for trainer-stage hooks (`on_train_start`, `on_epoch_end`, etc.).
-- `IntermediatePlot`: Visualizes model inference during training.
-- `MlflowLogger`: Logs trainer metrics and losses to an MLflow server.
-
-#### Training (`trainers`)
-- `AbstractTrainer`: Defines a modular training loop with support for custom models, datasets, losses, metrics, and callbacks. Exposes extensible hooks for batch and epoch-level logic.
+#### Repository Restructuring
+- Restructured the repository from a flat layout to the conventional `/src/package_name/` structure. 
+This change improves module discoverability, aligns with modern Python packaging standards, and reduces potential import conflicts. 
+All package-related code now resides under the `src/virtual_stain_flow/` directory.
+- Updated import paths throughout the codebase to reflect the new structure.
+- Adjusted setup scripts and documentation to accommodate the restructuring.
 
 ---
 
@@ -127,29 +109,46 @@ plots produced are logged as mlflow artifacts.
 
 ---
 
-## [0.3.0] - 2025-08
+## [0.1.0] - 2025-03-03
 
 ### Added
 
-#### New modular backbone for `models` subpackage
-##### Major changes:
-- Introduced a new modular and extensible `models` subpackage for building image-to-image translation models. 
-The subpackage is designed around a declarative style for creating U-Net-like architectures, with a hierarchy of abstractions:
-  - **Blocks** (`blocks.py`, `up_down_blocks.py`): Smallest modular units, categorized into computational blocks (e.g., `Conv2DNormActBlock`, `Conv2DConvNeXtBlock`) and spatial dimension altering blocks (e.g., `Conv2DDownBlock`, `PixelShuffle2DUpBlock`).
-  - **Stages** (`stages.py`): Sequences of blocks for downsampling or upsampling, such as `DownStage` and `UpStage`.
-  - **Encoder** (`encoder.py`): Implements the downsampling path of U-Net-like architectures using `DownStage` objects.
-  - **Decoder** (`decoder.py`): Implements the upsampling path with skip connections using `UpStage` objects.
-  - **BaseModel** and **BaseGeneratorModel** (`model.py`): Added abstract base classes for models, including functionality for saving weights, configuration handling, and defining the forward pass.
-  - **UNet** (`unet.py`): Predefined model class supporting fully convolutional and maxpooling-based U-Net variants.
-  - **UNeXt** (`unext.py`): Predefined U-Net variant with a ConvNeXtV2_tiny encoder and customizable decoder.
-- Added utility functions for normalization layers, activation functions, and type checking of block handles and configurations.
-- Refer to the `models` README for detailed explanations of components and usage examples.
+#### Core Framework
+- Introduced a minimal yet self-contained virtual staining framework structured around modular components for model training, dataset handling, transformations, metrics, and logging.
 
-### Refactored 
+#### Models (`models`)
+- Added `FNet`: Fully convolutional encoder-decoder for image-to-image translation.
+- Added `UNet`: U-Net variant using bilinear interpolation for upsampling.
+- Added GaN discriminators:
+  - `PatchBasedDiscriminator`: Outputs a probability map.
+  - `GlobalDiscriminator`: Outputs a global scalar probability.
 
-#### Repository Restructuring
-- Restructured the repository from a flat layout to the conventional `/src/package_name/` structure. 
-This change improves module discoverability, aligns with modern Python packaging standards, and reduces potential import conflicts. 
-All package-related code now resides under the `src/virtual_stain_flow/` directory.
-- Updated import paths throughout the codebase to reflect the new structure.
-- Adjusted setup scripts and documentation to accommodate the restructuring.
+#### Transforms (`transforms`)
+- `MinMaxNormalize`: Albumentations transform for range-based normalization.
+- `ZScoreNormalize`: Albumentations transform for z-score normalization.
+- `PixelDepthTransform`: Converts between image bit depths (e.g., 16-bit to 8-bit).
+
+#### Datasets (`datasets`)
+- `ImageDataset`: Dynamically loads multi-channel microscopy images from a PE2LoadData-formatted CSV; supports input/target channel selection and Albumentations transforms.
+- `PatchDataset`: Extends `ImageDataset` with configurable fixed-size cropping; supports object-centric patching and state retrieval (e.g., patch coordinates).
+- `GenericImageDataset`: A simplified dataset for user-formatted directories using regex-based site/channel parsing.
+- `CachedDataset`: Caches any of the above datasets in RAM to reduce I/O and speed up training.
+
+#### Losses (`losses`)
+- `AbstractLoss`: Base class defining standardized loss interface and trainer binding.
+- `GeneratorLoss`: Combines image reconstruction and adversarial loss for training GaN generators.
+- `WassersteinLoss`: Computes Wasserstein distance for GaN discriminator training.
+- `GradientPenaltyLoss`: Adds gradient penalty to improve discriminator stability.
+
+#### Metrics (`metrics`)
+- `AbstractMetrics`: Base class for accumulating, aggregating, and resetting batch-wise metrics.
+- `MetricsWrapper`: Wraps `torch.nn.Module` metrics with accumulation and aggregation logic.
+- `PSNR`: Computes Peak Signal-to-Noise Ratio (PSNR) for image quality evaluation.
+
+#### Callbacks (`callbacks`)
+- `AbstractCallback`: Base class for trainer-stage hooks (`on_train_start`, `on_epoch_end`, etc.).
+- `IntermediatePlot`: Visualizes model inference during training.
+- `MlflowLogger`: Logs trainer metrics and losses to an MLflow server.
+
+#### Training (`trainers`)
+- `AbstractTrainer`: Defines a modular training loop with support for custom models, datasets, losses, metrics, and callbacks. Exposes extensible hooks for batch and epoch-level logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.1] - 2025-10-16
+
+### Added
+
+#### Loss Computation Infrastructure 
+- Added `LossGroup` class to abstract out the complexity of computating multiple losses surrounding a single forward pass iteration from the trainer. 
+Itended as prepwork for incorporating more complex wGAN training.
+
+##### Components:
+- **`LossItem`** (`loss_group.py`): Wrapper around a `torch.nn.Module` loss to specify weights and arguments needed for computing. 
+- **`LossGroup`** (`loss_group.py`): Container class organizing all `LossItem`s to be computed during the same forward pass on the same set of context objects. 
+
+---
+
 ## [0.4.0] - 2025-09-07
 
 ### Added

--- a/src/virtual_stain_flow/losses/loss_group.py
+++ b/src/virtual_stain_flow/losses/loss_group.py
@@ -1,0 +1,138 @@
+"""
+loss_group.py
+
+LossGroup and LossItem classes for managing related loss computations.
+This abstraction is motivated by the complexity of managing computation
+    of losses from separate forward passes during the same training step,
+    which happens in wGAN training. 
+Also seconds as a way to centralize device management and loss weight control.
+The intended use of this module is by trainer classes, which should initialize
+    LossItem and LossGroup objects as part of their setup, and then generate
+    a dictionary of tensors containing all results of a forward pass and then
+    call the LossGroup object directly to arrive at the total loss, and simpify
+    the trainer logic substantially.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Union, Tuple, Dict, Sequence, List
+
+import torch
+
+from .AbstractLoss import AbstractLoss
+from .loss_utils import _get_loss_name, _scalar_from_ctx
+
+
+@dataclass
+class LossItem:
+    """
+    Wrapper data class around a torch.nn.Module loss.
+    Additionally specifies:
+    - loss weight
+    - args for computing the loss (such as those used in GANs, require 
+        non-standard inputs beyond (pred, target)). Here we abstract away
+        the input definition to the loss module to avoid having complex
+        logic in the trainer body. 
+    - enabled state (used or not in current backpropagation)
+    - compute at val (all loss items are by default also computed
+        during validation stage and logged as additional metrics.
+        However, some losses might not be suitable for validation time,
+        e.g. gradient penalty. This flag allows certain losses to be
+        skipped during train/validation.  
+    - device (
+        certain losses items may involve declaration of buffers/new tensors.
+        The LossItem class interfaces between the trainer and the nn.Module
+        losses and centralizes device management. 
+    )
+    """
+    module: Union[torch.nn.Module, AbstractLoss]
+    args: Union[str, Tuple[str, ...]] = ("pred", "target")
+    key: Optional[str] = None
+    weight: float = 1.0
+    enabled: bool = True
+    compute_at_val: bool = True
+    device: torch.device = torch.device("cpu")
+
+    def __post_init__(self):
+        
+        self.key = self.key or _get_loss_name(self.module)        
+        self.args = (self.args,) if isinstance(self.args, str) else self.args
+        
+        try:
+            self.module.to(self.device)
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to move loss module {self.key} "
+                f"to device {self.device}."
+            ) from e
+    
+    def __call__(
+        self,
+        train: bool,
+        **inputs: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Compute the loss value and the weighted loss value.
+        Returns zero tensors if the loss is disabled or if compute should be 
+        skipped during validation.
+
+        :param train: Whether the model is in training mode.
+        :param inputs: Keyword arguments containing all necessary inputs for the
+            loss computation.
+        :return: A tuple containing the raw loss and the weighted loss.
+        """
+        
+        if not self.enabled or (not train and not self.compute_at_val):
+            zero = _scalar_from_ctx(0.0, inputs)
+            return zero, zero
+        
+        missing = [kw for kw in self.args if kw not in inputs.keys()]
+        if missing:
+            raise ValueError(
+                f"Missing required arguments {missing} for loss computation."
+            )
+        
+        raw = self.module(*[inputs[arg] for arg in self.args])
+
+        return raw, raw * _scalar_from_ctx(self.weight, inputs)
+    
+@dataclass
+class LossGroup:
+    """
+    Container class to manage the computation of multiple loss items.
+    In this container class, each item is a LossItem object 
+        (see LossItem class for details), and all items organized under the
+        group are anticipated to be computed during the same forward pass.
+        The __call__ method of the LossGroup class takes the superset of
+        inputs required by all LossItems, iterates through the items and 
+        distributes the inputs accordingly, and then returns the total loss.
+    """
+    items: Sequence[LossItem]
+
+    @property
+    def item_names(self) -> List[str]:
+        return [item.key for item in self.items]
+    
+    def __call__(
+        self,
+        train: bool,
+        **inputs: torch.Tensor
+    ) -> Tuple[torch.Tensor, Dict[str, float]]:
+        """
+        Compute the total loss and individual loss values.
+
+        :param train: Whether the model is in training mode.
+        :input inputs: Keyword arguments containing all necessary inputs for the
+            loss computations.
+        :return: A tuple containing the total loss and a dictionary of 
+            individual loss values.
+        """
+        total = _scalar_from_ctx(0.0, inputs)
+
+        logs: Dict[str, float] = {}
+
+        for item in self.items:
+            raw, weighted = item(train, **inputs)
+            logs[item.key] = raw.item()
+            total += weighted
+        
+        return total, logs

--- a/src/virtual_stain_flow/losses/loss_utils.py
+++ b/src/virtual_stain_flow/losses/loss_utils.py
@@ -1,0 +1,50 @@
+"""
+loss_utils.py
+
+Utility functions for loss handling.
+"""
+
+from typing import Union, Dict
+
+import torch
+
+from .AbstractLoss import AbstractLoss
+
+
+def _get_loss_name(
+        loss_fn: Union[torch.nn.Module, AbstractLoss]
+) -> str:
+    """
+    Helper method to get the name of the loss function.
+    """
+    if isinstance(loss_fn, AbstractLoss) and hasattr(loss_fn, "metric_name"):
+        return loss_fn.metric_name
+    elif isinstance(loss_fn, torch.nn.Module):
+        return type(loss_fn).__name__
+    else:
+        raise TypeError(
+            "Expected loss_fn to be either a torch.nn.Module or "
+            "an AbstractLoss instance."
+            f"Got {type(loss_fn)} instead."
+        )
+    
+def _scalar_from_device(
+    value: float, 
+    device: torch.device,
+    dtype: torch.dtype = torch.float32,
+):
+    """
+    Helper method to convert a scalar value to a tensor in the specified device.
+    """
+    return torch.tensor(value, device=device, dtype=dtype)
+
+def _scalar_from_ctx(
+    value: float,
+    ctx: Dict[str, torch.Tensor]
+):
+    """
+    Helper method to convert a scalar value on the same device and 
+        of the same dtype as a given context object (dictionary of tensors)
+    """
+    t = next(iter(ctx.values()))
+    return _scalar_from_device(value, t.device, t.dtype)

--- a/tests/losses/conftest.py
+++ b/tests/losses/conftest.py
@@ -1,0 +1,56 @@
+"""Shared fixtures and utilities for loss tests."""
+
+import pytest
+import torch
+
+
+def get_available_devices():
+    """
+    Get list of available devices for testing.
+    
+    Returns:
+        List of torch.device objects available on the system.
+    """
+    devices = [torch.device("cpu")]
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            devices.append(torch.device(f"cuda:{i}"))
+    return devices
+
+
+@pytest.fixture(scope="session")
+def available_devices():
+    """Fixture providing list of available devices."""
+    return get_available_devices()
+
+
+@pytest.fixture
+def sample_inputs():
+    """Create sample inputs for loss computation."""
+    return {
+        "pred": torch.randn(4, 3, 32, 32),
+        "target": torch.randn(4, 3, 32, 32),
+        "pred2": torch.randn(4, 3, 32, 32),
+    }
+
+
+@pytest.fixture(scope="session")
+def has_cuda():
+    """Check if CUDA is available."""
+    return torch.cuda.is_available()
+
+
+@pytest.fixture(scope="session")
+def has_multiple_devices():
+    """Check if multiple devices (CPU + GPU or multiple GPUs) are available."""
+    return len(get_available_devices()) >= 2
+
+
+@pytest.fixture
+def sample_inputs():
+    """Create sample inputs for loss computation."""
+    return {
+        "pred": torch.randn(4, 3, 32, 32),
+        "target": torch.randn(4, 3, 32, 32),
+        "pred2": torch.randn(4, 3, 32, 32),
+    }

--- a/tests/losses/test_loss_group.py
+++ b/tests/losses/test_loss_group.py
@@ -1,0 +1,375 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from virtual_stain_flow.losses.loss_group import LossItem, LossGroup
+
+
+class SimpleLoss(nn.Module):
+    """Simple loss for testing: MSE loss."""
+    def forward(self, pred, target):
+        return torch.nn.functional.mse_loss(pred, target)
+
+
+class WeightedLoss(nn.Module):
+    """Loss with internal weights for device testing."""
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor(2.0))
+    
+    def forward(self, pred, target):
+        return self.weight * torch.nn.functional.l1_loss(pred, target)
+
+
+class TestLossItem:
+    """Test single LossItem functionality."""
+    
+    def test_loss_item_initialization(self):
+        """Test basic LossItem initialization."""
+        loss_module = SimpleLoss()
+        item = LossItem(
+            module=loss_module,
+            key="mse",
+            weight=2.0,
+            args=("pred", "target"),
+            device=torch.device("cpu")
+        )
+        
+        assert item.key == "mse"
+        assert item.weight == 2.0
+        assert item.args == ("pred", "target")
+        assert item.enabled is True
+        assert item.compute_at_val is True
+    
+    def test_loss_item_auto_key(self):
+        """Test automatic key generation."""
+        loss_module = SimpleLoss()
+        item = LossItem(
+            module=loss_module,
+            args=("pred", "target"),
+        )
+        
+        assert item.key is not None
+    
+    def test_loss_item_single_arg_conversion(self):
+        """Test that single string arg is converted to tuple."""
+        loss_module = SimpleLoss()
+        item = LossItem(
+            module=loss_module,
+            args="pred",
+        )
+        
+        assert isinstance(item.args, tuple)
+        assert item.args == ("pred",)
+    
+    def test_loss_item_computation(self, sample_inputs):
+        """Test loss computation returns correct values."""
+        loss_module = SimpleLoss()
+        item = LossItem(
+            module=loss_module,
+            weight=2.0,
+            args=("pred", "target"),
+        )
+        
+        raw, weighted = item(train=True, **sample_inputs)
+        
+        assert isinstance(raw, torch.Tensor)
+        assert isinstance(weighted, torch.Tensor)
+        assert weighted.item() == pytest.approx(raw.item() * 2.0)
+    
+    def test_loss_item_disabled(self, sample_inputs):
+        """Test that disabled loss returns zeros."""
+        loss_module = SimpleLoss()
+        item = LossItem(
+            module=loss_module,
+            weight=2.0,
+            args=("pred", "target"),
+            enabled=False,
+        )
+        
+        raw, weighted = item(train=True, **sample_inputs)
+        
+        assert raw.item() == 0.0
+        assert weighted.item() == 0.0
+    
+    def test_loss_item_compute_at_val_false(self, sample_inputs):
+        """
+        Test that loss is skipped during validation with compute_at_val=False.
+        """
+        loss_module = SimpleLoss()
+        item = LossItem(
+            module=loss_module,
+            weight=2.0,
+            args=("pred", "target"),
+            compute_at_val=False,
+        )
+        
+        # Should compute during training
+        raw_train, weighted_train = item(train=True, **sample_inputs)
+        assert raw_train.item() != 0.0
+        assert weighted_train.item() != 0.0
+        
+        # Should return zeros during validation
+        raw_val, weighted_val = item(train=False, **sample_inputs)
+        assert raw_val.item() == 0.0
+        assert weighted_val.item() == 0.0
+    
+    def test_loss_item_missing_args(self, sample_inputs):
+        """Test that missing arguments raise ValueError."""
+        loss_module = SimpleLoss()
+        item = LossItem(
+            module=loss_module,
+            args=("pred", "missing_arg"),
+        )
+        
+        with pytest.raises(ValueError, match="Missing required arguments"):
+            item(train=True, **sample_inputs)
+
+
+class TestLossGroup:
+    """Test LossGroup functionality."""
+    
+    def test_loss_group_initialization(self):
+        """Test basic LossGroup initialization."""
+        items = [
+            LossItem(
+                module=SimpleLoss(), 
+                key="loss1", 
+                args=("pred", "target")),
+            LossItem(
+                module=SimpleLoss(), 
+                key="loss2", 
+                args=("pred", "target")),
+        ]
+        group = LossGroup(items=items)
+        
+        assert len(group.items) == 2
+        assert group.item_names == ["loss1", "loss2"]
+    
+    def test_loss_group_computation(self, sample_inputs):
+        """Test loss group computes total and individual losses."""
+        items = [
+            LossItem(
+                module=SimpleLoss(), 
+                key="loss1", 
+                weight=1.0, 
+                args=("pred", "target")),
+            LossItem(
+                module=SimpleLoss(), 
+                key="loss2", 
+                weight=0.5, 
+                args=("pred2", "target")),
+        ]
+        group = LossGroup(items=items)
+        
+        total, logs = group(train=True, **sample_inputs)
+        
+        assert isinstance(total, torch.Tensor)
+        assert "loss1" in logs
+        assert "loss2" in logs
+        assert isinstance(logs["loss1"], float)
+        assert isinstance(logs["loss2"], float)
+    
+    def test_loss_group_with_disabled_item(self, sample_inputs):
+        """Test that disabled items don't contribute to total loss."""
+        items = [
+            LossItem(
+                module=SimpleLoss(), 
+                key="loss1", 
+                weight=1.0, 
+                args=("pred", "target"), 
+                enabled=True),
+            LossItem(
+                module=SimpleLoss(), 
+                key="loss2", 
+                weight=1.0, 
+                args=("pred", "target"), 
+                enabled=False),
+        ]
+        group = LossGroup(items=items)
+        
+        _, logs = group(train=True, **sample_inputs)
+        
+        assert logs["loss1"] != 0.0
+        assert logs["loss2"] == 0.0
+    
+    def test_loss_group_train_vs_val(self, sample_inputs):
+        """Test loss group behavior differs between train and val modes."""
+        items = [
+            LossItem(module=SimpleLoss(), key="loss1", weight=1.0, args=("pred", "target"), compute_at_val=True),
+            LossItem(module=SimpleLoss(), key="loss2", weight=1.0, args=("pred", "target"), compute_at_val=False),
+        ]
+        group = LossGroup(items=items)
+        
+        _, logs_train = group(train=True, **sample_inputs)
+        _, logs_val = group(train=False, **sample_inputs)
+        
+        # Both should compute during training
+        assert logs_train["loss1"] != 0.0
+        assert logs_train["loss2"] != 0.0
+        
+        # Only loss1 should compute during validation
+        assert logs_val["loss1"] != 0.0
+        assert logs_val["loss2"] == 0.0
+
+
+class TestDeviceManagement:
+    """Test device management across different hardware configurations."""
+    
+    def test_multiple_loss_groups_different_devices(self, available_devices):
+        """
+        Test that multiple loss groups can operate independently 
+            on different devices. This simulates having multiple separate 
+            instances of trainer running on different devices. 
+            All placeholder tensors generated by the items and groups should
+                be on the consistent devices and not error out.
+        """
+        if len(available_devices) < 2:
+            pytest.skip(
+                "Requires at least 2 devices (CPU + GPU or multiple GPUs)")
+        
+        device1, device2 = available_devices[0], available_devices[1]
+        
+        # Create first loss group for device1
+        group1_items = [
+            LossItem(
+                module=WeightedLoss(),
+                key="loss1_dev1",
+                weight=1.0,
+                args=("pred", "target"),
+                device=device1
+            ),
+            LossItem(
+                module=SimpleLoss(),
+                key="loss2_dev1",
+                weight=0.5,
+                args=("pred", "target"),
+                device=device1
+            ),
+        ]
+        group1 = LossGroup(items=group1_items)
+        
+        # Create second loss group for device2
+        group2_items = [
+            LossItem(
+                module=WeightedLoss(),
+                key="loss1_dev2",
+                weight=1.0,
+                args=("pred", "target"),
+                device=device2
+            ),
+            LossItem(
+                module=SimpleLoss(),
+                key="loss2_dev2",
+                weight=0.5,
+                args=("pred", "target"),
+                device=device2
+            ),
+        ]
+        group2 = LossGroup(items=group2_items)
+        
+        # Verify all modules in group1 are on device1
+        for item in group1.items:
+            if hasattr(item.module, 'parameters') and \
+                list(item.module.parameters()):
+                assert next(item.module.parameters()).device == device1
+        
+        # Verify all modules in group2 are on device2
+        for item in group2.items:
+            if hasattr(item.module, 'parameters') and \
+                list(item.module.parameters()):
+                assert next(item.module.parameters()).device == device2
+        
+        # Create inputs for device1
+        inputs_dev1 = {
+            "pred": torch.randn(4, 3, 32, 32, device=device1),
+            "target": torch.randn(4, 3, 32, 32, device=device1),
+        }
+        
+        # Create inputs for device2
+        inputs_dev2 = {
+            "pred": torch.randn(4, 3, 32, 32, device=device2),
+            "target": torch.randn(4, 3, 32, 32, device=device2),
+        }
+        
+        # Both groups should compute independently without issues
+        total1, logs1 = group1(train=True, **inputs_dev1)
+        total2, logs2 = group2(train=True, **inputs_dev2)
+        
+        # Verify outputs are on correct devices
+        assert total1.device == device1
+        assert total2.device == device2
+        
+        # Verify logs contain expected keys
+        assert "loss1_dev1" in logs1
+        assert "loss2_dev1" in logs1
+        assert "loss1_dev2" in logs2
+        assert "loss2_dev2" in logs2
+        
+        # Verify all losses were computed (non-zero)
+        assert logs1["loss1_dev1"] != 0.0
+        assert logs1["loss2_dev1"] != 0.0
+        assert logs2["loss1_dev2"] != 0.0
+        assert logs2["loss2_dev2"] != 0.0
+    
+    def test_loss_group_all_items_same_device(self, available_devices):
+        """
+        Test that all items within a single loss group work correctly 
+        when they're all on the same device.
+        """
+        if len(available_devices) < 2:
+            pytest.skip("Requires at least 2 devices")
+        
+        # Use GPU if available
+        device = available_devices[1]  
+        
+        items = [
+            LossItem(
+                module=WeightedLoss(),
+                key="loss1",
+                weight=1.0,
+                args=("pred", "target"),
+                device=device
+            ),
+            LossItem(
+                module=SimpleLoss(),
+                key="loss2",
+                weight=0.5,
+                args=("pred", "target"),
+                device=device
+            ),
+        ]
+        
+        # Verify all modules are on the same device
+        assert next(items[0].module.parameters()).device == device
+        
+        inputs = {
+            "pred": torch.randn(4, 3, 32, 32, device=device),
+            "target": torch.randn(4, 3, 32, 32, device=device),
+        }
+        
+        group = LossGroup(items=items)
+        total, logs = group(train=True, **inputs)
+        
+        assert total.device == device
+        assert "loss1" in logs
+        assert "loss2" in logs
+        assert logs["loss1"] != 0.0
+        assert logs["loss2"] != 0.0
+    
+    def test_loss_item_device_move_failure(self):
+        """Test that device move failures are handled appropriately."""
+        
+        class FailingLoss(nn.Module):
+            def to(self, device):
+                raise RuntimeError("Cannot move to device")
+            
+            def forward(self, pred, target):
+                return torch.tensor(0.0)
+        
+        with pytest.raises(RuntimeError, match="Failed to move loss module"):
+            LossItem(
+                module=FailingLoss(),
+                args=("pred", "target"),
+                device=torch.device("cpu")
+            )


### PR DESCRIPTION
In addition to centralizing loss module device management, the infrastructure also abstracts out the complexity of loss computation from the trainer. 
This maybe less prominent on simple training involving only the generator model and losses computed from the prediction and target, but will benefit more complex training where multiple parts of the model are updated asynchronously across different forward passes and the loss requires more than the prediction and target.   

## Introduces:
1. `losses/loss_group.py`: implements classes `LossItem` and `LossGroup` to allow for centralized loss computation from the same forward pass. 
2. `losses/loss_utils.py`: utils for `loss_group.py`
3. Tests surrounding loss group

This PR will be followed by a PR that actually integrates the new loss infrastructure into existing trainers and only with the second PR we will be fixing the multi-gpu training bug. 