### PR TITLE
PR brushing up abstract trainer class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,4 +2,14 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-    -   id: end-of-file-fixer
+      - id: end-of-file-fixer
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.0
+    hooks:
+      - id: ruff
+        args: ["--line-length=100"]
+      # linter.
+      - id: ruff-check
+        types_or: [ python, pyi ]
+        args: [ --fix ]

--- a/src/virtual_stain_flow/datasets/data_split.py
+++ b/src/virtual_stain_flow/datasets/data_split.py
@@ -1,3 +1,9 @@
+"""
+data_split.py
+
+Module for dataset splitting, to be called by trainers during initialization.
+"""
+
 from typing import Tuple
 
 from torch.utils.data import Dataset

--- a/src/virtual_stain_flow/datasets/data_split.py
+++ b/src/virtual_stain_flow/datasets/data_split.py
@@ -1,0 +1,54 @@
+from typing import Tuple
+
+from torch.utils.data import Dataset
+from torch.utils.data import DataLoader, random_split
+
+
+def default_random_split(
+    dataset: Dataset, 
+    **kwargs
+) -> Tuple[DataLoader, DataLoader, DataLoader]:
+    """
+    Randomly split a dataset into train, validation, and test sets.
+    :param dataset: The dataset to split.
+    :param train_frac: Fraction of data to use for training (default: 0.7).
+    :param val_frac: Fraction of data to use for validation (default: 0.15).
+    :param test_frac: Fraction of data to use for testing (default: remaining).
+    :param batch_size: Batch size for the DataLoaders (default: 4).
+    :param shuffle: Whether to shuffle the data in the DataLoaders
+        (default: True).
+    :return: A tuple of DataLoaders for (train, val, test) splits.    
+    """
+    
+    train_frac = kwargs.get("train_frac", 0.7)
+    val_frac = kwargs.get("val_frac", 0.15)
+    test_frac = kwargs.get(
+        "test_frac", 1.0 - train_frac - val_frac
+    )
+    
+    for frac in (train_frac, val_frac, test_frac):
+        if not (0.0 < frac < 1.0):
+            raise ValueError(
+                "train_frac, val_frac, test_frac must be in (0.0, 1.0)"
+            )
+    if not train_frac + val_frac + test_frac <= 1.0 + 1e-8:
+        raise ValueError(
+            "train_frac + val_frac + test_frac must sum to 1.0"
+        )
+    
+    n_train = int(len(dataset) * train_frac)
+    n_val = int(len(dataset) * val_frac)
+    n_test = len(dataset) - n_train - n_val
+
+    train_split, val_split, test_split = random_split(dataset, 
+        [n_train, n_val, n_test]
+    )
+
+    batch_size = kwargs.get("batch_size", 4)
+    shuffle = kwargs.get("shuffle", True)
+
+    return tuple([
+        DataLoader(split, shuffle=shuffle, batch_size=batch_size) for split in [
+            train_split, val_split, test_split
+        ]
+    ])

--- a/src/virtual_stain_flow/trainers/AbstractTrainer.py
+++ b/src/virtual_stain_flow/trainers/AbstractTrainer.py
@@ -1,3 +1,7 @@
+"""
+AbstractTrainer.py
+"""
+
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import Dict, Optional, Literal

--- a/src/virtual_stain_flow/trainers/AbstractTrainer.py
+++ b/src/virtual_stain_flow/trainers/AbstractTrainer.py
@@ -1,12 +1,10 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import List, Tuple, Dict, Optional
+from typing import Dict, Optional
 
 import torch
 from torch.utils.data import DataLoader, random_split
 
-from ..losses.loss_group import LossGroup
-from ..fp_ctx.forward_groups import ForwardGroup
 from ..metrics.AbstractMetrics import AbstractMetrics
 
 

--- a/src/virtual_stain_flow/trainers/AbstractTrainer.py
+++ b/src/virtual_stain_flow/trainers/AbstractTrainer.py
@@ -5,11 +5,12 @@ from typing import Dict, Optional, Literal
 import torch
 from torch.utils.data import DataLoader, random_split
 
+from .trainer_protocol import TrainerProtocol
 from ..metrics.AbstractMetrics import AbstractMetrics
 from ..vsf_logging import MlflowLogger
 
 
-class AbstractTrainer(ABC):
+class AbstractTrainer(TrainerProtocol, ABC):
     """
     Abstract trainer class for img2img translation models.
     """

--- a/src/virtual_stain_flow/trainers/trainer_protocol.py
+++ b/src/virtual_stain_flow/trainers/trainer_protocol.py
@@ -12,7 +12,9 @@ import torch
 @runtime_checkable
 class TrainerProtocol(Protocol):
     """
-    Protocol for defining a trainer class.
+    Protocol for defining the minimal behavior and attribute of a trainer class.
+    This protocol is useful for type hinting and checking for trainer object
+        in the `vsf_logging` subpackage to avoid circular imports.
     """
 
     _batch_size: int

--- a/src/virtual_stain_flow/trainers/trainer_protocol.py
+++ b/src/virtual_stain_flow/trainers/trainer_protocol.py
@@ -1,0 +1,48 @@
+from typing import Protocol, Dict, runtime_checkable
+
+import torch
+
+
+@runtime_checkable
+class TrainerProtocol(Protocol):
+    """
+    Protocol for defining a trainer class.
+    """
+
+    _batch_size: int
+    _epochs: int
+    _patience: int
+    _device: torch.device
+
+    def train_step(
+        self,
+        inputs: torch.Tensor,
+        targets: torch.Tensor
+    ) -> Dict[str, float]: ...
+
+    def evaluate_step(
+        self,
+        inputs: torch.Tensor,
+        targets: torch.Tensor
+    ) -> Dict[str, float]: ...
+
+    def train_epoch(self) -> Dict[str, float]: ...
+
+    def evaluate_epoch(self) -> Dict[str, float]: ...
+
+    def train(self, num_epochs: int) -> None: ...
+
+    @property
+    def epoch(self) -> int: ...
+
+    @property
+    def device(self) -> torch.device: ...
+
+    @property
+    def metrics(self) -> Dict[str, torch.nn.Module]: ...
+
+    @property
+    def model(self) -> torch.nn.Module: ...
+
+    @property
+    def best_model(self) -> torch.nn.Module: ...

--- a/src/virtual_stain_flow/trainers/trainer_protocol.py
+++ b/src/virtual_stain_flow/trainers/trainer_protocol.py
@@ -1,3 +1,9 @@
+"""
+trainer_protocol.py
+
+Protocol for defining behavior and needed attributes of a trainer class.
+"""
+
 from typing import Protocol, Dict, runtime_checkable
 
 import torch

--- a/src/virtual_stain_flow/vsf_logging/MlflowLogger.py
+++ b/src/virtual_stain_flow/vsf_logging/MlflowLogger.py
@@ -1,21 +1,18 @@
-import os
+"""
+MlflowLogger.py
+"""
+
 import pathlib
 import tempfile
 from typing import Union, Dict, Optional, List, Any
 
 import mlflow
-import torch
 from torch import nn
 
 from ..trainers.trainer_protocol import TrainerProtocol
-# from ..trainers.AbstractTrainer import (
-#     AbstractTrainer)
 from .callbacks.LoggerCallback import (
     AbstractLoggerCallback,
-    log_type,
-    log_artifact_type,
-    log_param_type,
-    log_metric_type
+    log_type
 )
 
 path_type = Union[pathlib.Path, str]

--- a/src/virtual_stain_flow/vsf_logging/MlflowLogger.py
+++ b/src/virtual_stain_flow/vsf_logging/MlflowLogger.py
@@ -7,8 +7,9 @@ import mlflow
 import torch
 from torch import nn
 
-from ..trainers.logging_trainers import (
-    AbstractLoggingTrainer)
+from ..trainers.trainer_protocol import TrainerProtocol
+# from ..trainers.AbstractTrainer import (
+#     AbstractTrainer)
 from .callbacks.LoggerCallback import (
     AbstractLoggerCallback,
     log_type,
@@ -22,11 +23,11 @@ path_type = Union[pathlib.Path, str]
 class MlflowLogger:
     """
     MLflow Logger for logging training runs, metrics, artifacts, and parameters, intended to be
-        used with the AbstractLoggingTrainer subclasses.
+        used with the TrainerProtocol class.
     
     This class is distinct and independent from the `virtual_stain_flow.callback` classes,
         in that it is no longer an optional callback to be supplied during trainer initialization 
-        but a required parameter for the `train` function of the AbstractLoggingTrainer subclasses,
+        but a required parameter for the `train` function of the TrainerProtocol class,
         bound to a single train session.
     
     This class can accept a list of `AbstractLoggerCallback` subclasses so callback products are
@@ -97,7 +98,7 @@ class MlflowLogger:
             "description": description
         }
 
-        self.trainer: Optional[AbstractLoggingTrainer] = None
+        self.trainer: Optional[TrainerProtocol] = None
 
         if isinstance(tags, dict):
             for key, value in tags.items():


### PR DESCRIPTION
Previously logger support is achieved by wrapping `AbstractTrainer` with yet another layer of abstract class, which is redundant, this PR adds logger support to `AbstractTrainer` directly along side a few minor refactoring (no change to functionality).

## Refactors:
`AbstractTrainer.py`:
- Imports
- Remove redundant type hint docstrings
- Centralizes all loss state tracking initialization as a private method
- Isolates data splitting logic to a separate module `data_split.py`

## Adds:
`AbstractTrainer.py`:
- `train` method support to logger class
`TrainerProtocol.py`:
- adds separate protocol class for future circular import prevention.